### PR TITLE
Car reference fs

### DIFF
--- a/ipldstore/car.py
+++ b/ipldstore/car.py
@@ -1,0 +1,84 @@
+"""
+CAR handling functions.
+"""
+
+from io import BufferedIOBase
+from typing import List, Optional, Tuple
+
+import dag_cbor
+from multiformats import CID, varint, multicodec, multihash
+
+from .utils import is_cid_list, StreamLike, ensure_stream
+
+
+def decode_car_header(stream: BufferedIOBase) -> List[CID]:
+    """
+    Decodes a CAR header and returns the list of contained roots.
+    """
+    header_size = varint.decode(stream)
+    header = dag_cbor.decode(stream.read(header_size))
+    if not isinstance(header, dict):
+        raise ValueError("no valid CAR header found")
+    roots = header["roots"]
+    if not isinstance(roots, list):
+        raise ValueError("CAR header doesn't contain roots")
+    if not is_cid_list(roots):
+        raise ValueError("CAR roots do not only contain CIDs")
+    return roots
+
+
+def decode_raw_car_block(stream: BufferedIOBase) -> Optional[Tuple[CID, bytes]]:
+    try:
+        block_size = varint.decode(stream)
+    except ValueError:
+        # stream has likely been consumed entirely
+        return None
+
+    data = stream.read(block_size)
+    # as the size of the CID is variable but not explicitly given in
+    # the CAR format, we need to partially decode each CID to determine
+    # its size and the location of the payload data
+    if data[0] == 0x12 and data[1] == 0x20:
+        # this is CIDv0
+        cid_version = 0
+        default_base = "base58btc"
+        cid_codec: Union[int, multicodec.Multicodec] = DagPbCodec
+        hash_codec: Union[int, multihash.Multihash] = Sha256Hash
+        cid_digest = data[2:34]
+        data = data[34:]
+    else:
+        # this is CIDv1(+)
+        cid_version, _, data = varint.decode_raw(data)
+        if cid_version != 1:
+            raise ValueError(f"CIDv{cid_version} is currently not supported")
+        default_base = "base32"
+        cid_codec, _, data = multicodec.unwrap_raw(data)
+        hash_codec, _, data = varint.decode_raw(data)
+        digest_size, _, data = varint.decode_raw(data)
+        cid_digest = data[:digest_size]
+        data = data[digest_size:]
+    cid = CID(default_base, cid_version, cid_codec, (hash_codec, cid_digest))
+
+    if not cid.hashfun.digest(data) == cid.digest:
+        raise ValueError(f"CAR is corrupted. Entry '{cid}' could not be verified")
+
+    return cid, bytes(data)
+
+
+def read_car(stream_or_bytes: StreamLike):
+    """
+    Reads a CAR.
+
+    Returns
+    -------
+    roots : List[CID]
+        Roots as given by the CAR header
+    blocks : Iterator[Tuple[cid, BytesLike]]
+        Iterator over all blocks contained in the CAR
+    """
+    stream = ensure_stream(stream_or_bytes)
+    roots = decode_car_header(stream)
+    def blocks():
+        while (next_block := decode_raw_car_block(stream)) is not None:
+            yield next_block
+    return roots, blocks()

--- a/ipldstore/car.py
+++ b/ipldstore/car.py
@@ -19,6 +19,8 @@ def decode_car_header(stream: BufferedIOBase) -> List[CID]:
     header = dag_cbor.decode(stream.read(header_size))
     if not isinstance(header, dict):
         raise ValueError("no valid CAR header found")
+    if header["version"] != 1:
+        raise ValueError("CAR is not version 1")
     roots = header["roots"]
     if not isinstance(roots, list):
         raise ValueError("CAR header doesn't contain roots")

--- a/ipldstore/car_reference_fs.py
+++ b/ipldstore/car_reference_fs.py
@@ -1,0 +1,60 @@
+import json
+from typing import Dict, Any, Iterator, Tuple
+
+import dag_cbor
+from multiformats import CID, multicodec
+
+from .car import read_car, CARBlockLocation
+from .ipldstore import inline_objects
+from .utils import StreamLike
+
+def collect_tree_objects(stream_or_bytes: StreamLike) -> Tuple[CID, Dict[CID, Any], Dict[CID, CARBlockLocation]]:
+    DagCborCodec = multicodec.get("dag-cbor")
+
+    roots, blocks = read_car(stream_or_bytes)
+    if len(roots) != 1:
+        raise ValueError("need single-rooted car")
+    root = roots[0]
+
+    object_locations = {}
+    cbor_objects = {}
+    for cid, data, location in blocks:
+        object_locations[cid] = location
+        if cid.codec == DagCborCodec:
+            cbor_objects[cid] = data
+
+    return root, cbor_objects, object_locations
+
+
+def car2reference_fs_refs(stream_or_bytes: StreamLike, stream_name: str) -> Dict[str, Any]:
+    root, cbor_objects, object_locations = collect_tree_objects(stream_or_bytes)
+
+    tree = dag_cbor.decode(cbor_objects[root])
+    assert isinstance(tree, dict)
+    sep = "/"
+
+    def iter_nested(prefix: str, mapping: Dict[str, Any]) -> Iterator[Tuple[str, Any]]:
+        for key, value in mapping.items():
+            key_parts = key.split(sep)
+            if key_parts[-1] in inline_objects:
+                yield prefix + key, value
+            elif isinstance(value, dict):
+                yield from iter_nested(prefix + key + sep, value)
+            else:
+                yield prefix + key, value
+
+    refs: Dict[str, Any] = {}
+    for key, content in iter_nested("", tree):
+        if isinstance(content, CID):
+            loc = object_locations[content]
+            refs[key] = [stream_name, loc.payload_offset, loc.payload_size]
+        else:
+            refs[key] = json.dumps(content)
+
+    return refs
+
+
+def car2reference_fs(filename: str) -> Dict[str, Any]:
+    with open(filename, "rb") as stream:
+        refs = car2reference_fs_refs(stream, "{{a}}")
+    return {"version": 1, "templates": {"a": filename}, "refs": refs}

--- a/ipldstore/contentstore.py
+++ b/ipldstore/contentstore.py
@@ -118,7 +118,7 @@ class ContentAddressableStore(ABC):
         roots, blocks = read_car(stream_or_bytes)
         roots = [self.normalize_cid(root) for root in roots]
 
-        for cid, data in blocks:
+        for cid, data, _ in blocks:
             self.put_raw(bytes(data), cid.codec)
 
         return roots

--- a/ipldstore/contentstore.py
+++ b/ipldstore/contentstore.py
@@ -11,6 +11,9 @@ from typing_validation import validate
 
 import requests
 
+from .car import read_car
+from .utils import StreamLike
+
 
 ValueType = Union[bytes, DagCborEncodable]
 
@@ -18,10 +21,6 @@ RawCodec = multicodec.get("raw")
 DagCborCodec = multicodec.get("dag-cbor")
 DagPbCodec = multicodec.get("dag-pb")
 Sha256Hash = multihash.get("sha2-256")
-
-
-def is_cid_list(os: List[object]) -> TypeGuard[List[CID]]:
-    return all(isinstance(o, CID) for o in os)
 
 
 class ContentAddressableStore(ABC):
@@ -115,74 +114,14 @@ class ContentAddressableStore(ABC):
                     bytes_written += self._to_car(child, stream, already_written)
         return bytes_written
 
-    def import_car(self, stream_or_bytes: Union[BufferedIOBase, bytes]) -> List[CID]:
-        validate(stream_or_bytes, Union[BufferedIOBase, bytes])
-        if isinstance(stream_or_bytes, bytes):
-            stream: BufferedIOBase = BytesIO(stream_or_bytes)
-        else:
-            stream = stream_or_bytes
+    def import_car(self, stream_or_bytes: StreamLike) -> List[CID]:
+        roots, blocks = read_car(stream_or_bytes)
+        roots = [self.normalize_cid(root) for root in roots]
 
-        roots = [self.normalize_cid(root) for root in decode_car_header(stream)]
-
-        while (next_block := decode_raw_car_block(stream)) is not None:
-            cid, data = next_block
+        for cid, data in blocks:
             self.put_raw(bytes(data), cid.codec)
 
         return roots
-
-
-def decode_car_header(stream: BufferedIOBase) -> List[CID]:
-    """
-    Decodes a CAR header and returns the list of contained roots.
-    """
-    header_size = varint.decode(stream)
-    header = dag_cbor.decode(stream.read(header_size))
-    if not isinstance(header, dict):
-        raise ValueError("no valid CAR header found")
-    roots = header["roots"]
-    if not isinstance(roots, list):
-        raise ValueError("CAR header doesn't contain roots")
-    if not is_cid_list(roots):
-        raise ValueError("CAR roots do not only contain CIDs")
-    return roots
-
-
-def decode_raw_car_block(stream: BufferedIOBase) -> Optional[Tuple[CID, bytes]]:
-    try:
-        block_size = varint.decode(stream)
-    except ValueError:
-        # stream has likely been consumed entirely
-        return None
-
-    data = stream.read(block_size)
-    # as the size of the CID is variable but not explicitly given in
-    # the CAR format, we need to partially decode each CID to determine
-    # its size and the location of the payload data
-    if data[0] == 0x12 and data[1] == 0x20:
-        # this is CIDv0
-        cid_version = 0
-        default_base = "base58btc"
-        cid_codec: Union[int, multicodec.Multicodec] = DagPbCodec
-        hash_codec: Union[int, multihash.Multihash] = Sha256Hash
-        cid_digest = data[2:34]
-        data = data[34:]
-    else:
-        # this is CIDv1(+)
-        cid_version, _, data = varint.decode_raw(data)
-        if cid_version != 1:
-            raise ValueError(f"CIDv{cid_version} is currently not supported")
-        default_base = "base32"
-        cid_codec, _, data = multicodec.unwrap_raw(data)
-        hash_codec, _, data = varint.decode_raw(data)
-        digest_size, _, data = varint.decode_raw(data)
-        cid_digest = data[:digest_size]
-        data = data[digest_size:]
-    cid = CID(default_base, cid_version, cid_codec, (hash_codec, cid_digest))
-
-    if not cid.hashfun.digest(data) == cid.digest:
-        raise ValueError(f"CAR is corrupted. Entry '{cid}' could not be verified")
-
-    return cid, bytes(data)
 
 
 class MappingCAStore(ContentAddressableStore):

--- a/ipldstore/contentstore.py
+++ b/ipldstore/contentstore.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import MutableMapping, Optional, Union, overload, Iterator, MutableSet, List, Tuple
+from typing import MutableMapping, Optional, Union, overload, Iterator, MutableSet, List
 from io import BufferedIOBase, BytesIO
-
-from typing_extensions import TypeGuard
 
 from multiformats import CID, multicodec, multibase, multihash, varint
 import dag_cbor
@@ -19,8 +17,6 @@ ValueType = Union[bytes, DagCborEncodable]
 
 RawCodec = multicodec.get("raw")
 DagCborCodec = multicodec.get("dag-cbor")
-DagPbCodec = multicodec.get("dag-pb")
-Sha256Hash = multihash.get("sha2-256")
 
 
 class ContentAddressableStore(ABC):
@@ -58,7 +54,7 @@ class ContentAddressableStore(ABC):
         else:
             return self.put_raw(dag_cbor.encode(value), DagCborCodec)
 
-    def normalize_cid(self, cid: CID) -> CID: # pylint: disable=no-self-use
+    def normalize_cid(self, cid: CID) -> CID:  # pylint: disable=no-self-use
         return cid
 
     @overload

--- a/ipldstore/ipldstore.py
+++ b/ipldstore/ipldstore.py
@@ -14,6 +14,7 @@ import dag_cbor
 from numcodecs.compat import ensure_bytes  # type: ignore
 
 from .contentstore import ContentAddressableStore, MappingCAStore
+from .utils import StreamLike
 
 if sys.version_info >= (3, 9):
     MutableMappingT = MutableMapping
@@ -120,14 +121,14 @@ class IPLDStore(MutableMappingSB):
     def to_car(self, stream: Optional[BufferedIOBase] = None) -> Union[int, bytes]:
         return self._store.to_car(self.freeze(), stream)
 
-    def import_car(self, stream: Union[BufferedIOBase, bytes]) -> None:
+    def import_car(self, stream: StreamLike) -> None:
         roots = self._store.import_car(stream)
         if len(roots) != 1:
             raise ValueError(f"CAR must have a single root, the given CAR has {len(roots)} roots!")
         self.set_root(roots[0])
 
     @classmethod
-    def from_car(cls, stream: Union[BufferedIOBase, bytes]) -> "IPLDStore":
+    def from_car(cls, stream: StreamLike) -> "IPLDStore":
         instance = cls()
         instance.import_car(stream)
         return instance

--- a/ipldstore/ipldstore.py
+++ b/ipldstore/ipldstore.py
@@ -5,12 +5,6 @@ Implementation of a MutableMapping based on IPLD data structures.
 from io import BufferedIOBase
 from collections.abc import MutableMapping
 import sys
-if sys.version_info >= (3, 9):
-    MutableMappingT = MutableMapping
-    MutableMappingSB = MutableMapping[str, bytes]
-else:
-    from typing import MutableMapping as MutableMappingT
-    MutableMappingSB = MutableMapping
 from dataclasses import dataclass
 from typing import Optional, Callable, Any, TypeVar, Union, Iterator, overload, List, Dict
 import json
@@ -21,6 +15,12 @@ from numcodecs.compat import ensure_bytes  # type: ignore
 
 from .contentstore import ContentAddressableStore, MappingCAStore
 
+if sys.version_info >= (3, 9):
+    MutableMappingT = MutableMapping
+    MutableMappingSB = MutableMapping[str, bytes]
+else:
+    from typing import MutableMapping as MutableMappingT
+    MutableMappingSB = MutableMapping
 
 @dataclass
 class InlineCodec:

--- a/ipldstore/utils.py
+++ b/ipldstore/utils.py
@@ -1,0 +1,23 @@
+"""
+Some utilities.
+"""
+
+from io import BufferedIOBase, BytesIO
+from typing import List, Union
+
+from multiformats import CID
+from typing_validation import validate
+from typing_extensions import TypeGuard
+
+StreamLike = Union[BufferedIOBase, bytes]
+
+def ensure_stream(stream_or_bytes: StreamLike) -> BufferedIOBase:
+    validate(stream_or_bytes, StreamLike)
+    if isinstance(stream_or_bytes, bytes):
+        return BytesIO(stream_or_bytes)
+    else:
+        return stream_or_bytes
+
+
+def is_cid_list(os: List[object]) -> TypeGuard[List[CID]]:
+    return all(isinstance(o, CID) for o in os)

--- a/ipldstore/utils.py
+++ b/ipldstore/utils.py
@@ -2,17 +2,15 @@
 Some utilities.
 """
 
-from io import BufferedIOBase, BytesIO
-from typing import List, Union
+from io import BytesIO
+from typing import List, Union, BinaryIO
 
 from multiformats import CID
-from typing_validation import validate
 from typing_extensions import TypeGuard
 
-StreamLike = Union[BufferedIOBase, bytes]
+StreamLike = Union[BinaryIO, bytes]
 
-def ensure_stream(stream_or_bytes: StreamLike) -> BufferedIOBase:
-    validate(stream_or_bytes, StreamLike)
+def ensure_stream(stream_or_bytes: StreamLike) -> BinaryIO:
     if isinstance(stream_or_bytes, bytes):
         return BytesIO(stream_or_bytes)
     else:

--- a/test/test_car.py
+++ b/test/test_car.py
@@ -1,0 +1,11 @@
+from io import BytesIO
+
+import ipldstore.car as car
+
+import pytest
+
+def test_car_reject_v2():
+    v2_start = bytes.fromhex("0aa16776657273696f6e02")
+    stream = BytesIO(v2_start)
+    with pytest.raises(ValueError):
+        car.decode_car_header(stream)

--- a/test/test_car_reference_fs.py
+++ b/test/test_car_reference_fs.py
@@ -1,0 +1,29 @@
+import os
+import json
+import tempfile
+
+from ipldstore.car_reference_fs import car2reference_fs
+from ipldstore import IPLDStore
+
+import xarray as xr
+
+import pytest
+
+def test_car_reference_fs():
+    basename = "test_car_reference_fs"
+    m = IPLDStore()
+    ds = xr.Dataset({"a": (("a",), [1, 2, 3]),
+                     "b": (("a",), [5., 6., 8.])})
+    ds.to_zarr(m)
+
+    with tempfile.TemporaryDirectory() as folder:
+        carfilename = os.path.join(folder, basename + ".car")
+        indexfilename = os.path.join(folder, basename + ".json")
+        with open(carfilename, "wb") as carfile:
+            m.to_car(carfile)
+        ref = car2reference_fs(carfilename)
+        with open(indexfilename, "w") as reffile:
+            json.dump(ref, reffile)
+
+        ds2 = xr.open_zarr("reference::" + indexfilename)
+        assert ds.identical(ds2)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,3 +3,5 @@ pytest
 pytest-cov
 cbor2
 xarray
+fsspec
+jinja2

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     mypy
     types-requests
 commands =
-    mypy --strict ipldstore
+    mypy --strict --show-error-codes --warn-unused-ignores ipldstore
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
This is a potential implementation for #2.

I don't yet know what a good interface would be. Currently it can be used to generate a reference filesystem from an existing car file as follows:

```python
from ipldstore.car_reference_fs import car2reference_fs
carfilename = "test.car"
indexfilename = "index.car"
ref = car2reference_fs(carfilename)    
with open(indexfilename, "w") as reffile:    
    json.dump(ref, reffile)  
```